### PR TITLE
fix: issue with non-closed tag for plenary slot

### DIFF
--- a/themes/booster/layouts/session/plenary.html
+++ b/themes/booster/layouts/session/plenary.html
@@ -10,7 +10,7 @@
                             {{if gt (len .Params.talks) 1}}
                                 <span>— {{ .Title }}</span>
                             {{ else }}
-                                <span>— <a href="{{ ($.Site.GetPage (printf "/talk/%s" (index .Params.talks 0) )).RelPermalink }}">{{ .Title }}</span>
+                                <span>— <a href="{{ ($.Site.GetPage (printf "/talk/%s" (index .Params.talks 0) )).RelPermalink }}">{{ .Title }}</a></span>
                             {{ end }}
                         {{ end }}
                     {{ end }}


### PR DESCRIPTION
Fixes issue with anchor tag not being closed for plenary type slot items as seen in screenshot:
<img width="1021" alt="Screenshot 2022-03-21 at 20 36 18" src="https://user-images.githubusercontent.com/606374/159350471-e2c86bd8-1b64-45ac-8bab-cfc1ef86c698.png">
