### PR TITLE
Change title of Vegard Haugstvedt's talk

### DIFF
--- a/content/talk/119-getting-rid-of-every-paper-application-for-nav-in-two-years.md
+++ b/content/talk/119-getting-rid-of-every-paper-application-for-nav-in-two-years.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting rid of every paper application for NAV in two years"
+title: "Getting rid of every paper application for NAV in three years"
 talk_type: "Experience report (30 min)"
 authors:
     - Vegard Haugstvedt


### PR DESCRIPTION
It is a mistake on my end that the title said we will get rid of all the paper applications in two years. In reality, it is a little over 2,5 years, and changing it to three years seems correct. Hopefully a minor change that doesn't cause any problems. :)